### PR TITLE
Bv fixinguserprofileidoncomments

### DIFF
--- a/Tabloid/Repositories/CommentRepository.cs
+++ b/Tabloid/Repositories/CommentRepository.cs
@@ -143,7 +143,7 @@ namespace Tabloid.Repositories
             }
         }
 
-        public void AddComment(Comment comment)
+        public void AddComment(int userProfileId, Comment comment)
         {
             using (var conn = Connection)
             {
@@ -157,7 +157,7 @@ namespace Tabloid.Repositories
                     ";
 
                     cmd.Parameters.AddWithValue("@postId", comment.PostId);
-                    cmd.Parameters.AddWithValue("@userProfileId", comment.UserProfileId);
+                    cmd.Parameters.AddWithValue("@userProfileId", userProfileId);
                     cmd.Parameters.AddWithValue("@subject", comment.Subject);
                     cmd.Parameters.AddWithValue("@content", comment.Content);
                     cmd.Parameters.AddWithValue("@createDateTime", DateTime.Now);

--- a/Tabloid/Repositories/ICommentRepository.cs
+++ b/Tabloid/Repositories/ICommentRepository.cs
@@ -12,7 +12,7 @@ namespace Tabloid.Repositories
 
         Comment GetCommentById(int id);
 
-        void AddComment(Comment comment);
+        void AddComment(int userProfileId, Comment comment);
 
         void UpdateComment(Comment comment);
 

--- a/Tabloid/client/src/components/Comments/CommentForm.js
+++ b/Tabloid/client/src/components/Comments/CommentForm.js
@@ -3,11 +3,10 @@ import { useHistory, useParams } from "react-router-dom";
 import { addComment } from "../../modules/commentManager";
 import { Form, FormGroup, Button, Container } from "reactstrap";
 
-const AddNewComment = ({ post }) => {
+const AddNewComment = () => {
     const { id } = useParams();
     const [comment, setComment] = useState({
         postId: id,
-        userProfileId: post.comment.userProfileId,
         subject: "",
         content: ""
     });

--- a/Tabloid/client/src/components/Comments/CommentForm.js
+++ b/Tabloid/client/src/components/Comments/CommentForm.js
@@ -3,11 +3,11 @@ import { useHistory, useParams } from "react-router-dom";
 import { addComment } from "../../modules/commentManager";
 import { Form, FormGroup, Button, Container } from "reactstrap";
 
-const AddNewComment = () => {
+const AddNewComment = ({ post }) => {
     const { id } = useParams();
     const [comment, setComment] = useState({
         postId: id,
-        userProfileId: 1,
+        userProfileId: post.comment.userProfileId,
         subject: "",
         content: ""
     });


### PR DESCRIPTION
# Description
When adding a comment, the comment now has the correct userId attached to it.
Fixes # userId hard coded into adding a comment
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
# Testing Instructions
Start server, run npm start from client directory, click posts, click the title of a post taking you to post details, click view comments, click add comment, fill in the necessary data, click save comment, make sure the comment you just added has the logged in user's displayname attached.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works